### PR TITLE
Remove config:cache from composer test script

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -72,11 +72,7 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ],
-        "test": [
-            "@php artisan config:clear",
-            "pest --no-interaction --coverage",
-            "@php artisan config:cache"
-            ],
+        "test": "@php artisan config:clear && pest --no-interaction --coverage",
         "test-with-coverage": "pest --no-interaction --coverage-clover ./coverage.xml",
         "cs": "php-cs-fixer fix --dry-run",
         "cs-fix": "php-cs-fixer fix"


### PR DESCRIPTION
This was intended as a workaround for the problem that we need to run artisan config:cache after running tests in order to access the local database afterwards. However, this is not a suitable workaround since there is no option to provide arguments to a specific command in a script list as used here. This leads to the name of the test file to execute when running only one test file to the cache:clear command that errors.