### PR TITLE
Use collcetion driver when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       DB_USERNAME: laravel
       DB_PASSWORD: laravel
       DB_HOST: '127.0.0.1'
-      SCOUT_DRIVER: collection
 
     steps:
     - name: Setup PHP

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -30,5 +30,7 @@
 
         <server name="SCRAPERS_HOST" value="localhost"/>
         <server name="SCRAPERS_PORT" value="5000"/>
+
+        <server name="SCOUT_DRIVER" value="collection" force="true"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Setting the env variable in `phpunit.yml` will make sure we always use the collection driver when running tests, no matter wether they are executed locally or in CI.