### PR TITLE
Exclude non-matched primary votes from /votes index page

### DIFF
--- a/app/app/Session.php
+++ b/app/app/Session.php
@@ -44,4 +44,9 @@ class Session extends Model
     {
         return $this->votes()->where('type', VoteTypeEnum::PRIMARY());
     }
+
+    public function matchedPrimaryVotes()
+    {
+        return $this->primaryVotes()->whereHas('votingList');
+    }
 }

--- a/app/resources/views/voting-lists/index.blade.php
+++ b/app/resources/views/voting-lists/index.blade.php
@@ -7,7 +7,7 @@
                 @foreach ($sessions as $session)
                     <h2 class="beta">{{ $session->display_title }}</h2>
 
-                    @foreach ($session->primaryVotes as $vote)
+                    @foreach ($session->matchedPrimaryVotes as $vote)
                         <x-vote-card :vote="$vote" />
                     @endforeach
                 @endforeach

--- a/app/tests/Feature/Http/VotingLists/IndexTest.php
+++ b/app/tests/Feature/Http/VotingLists/IndexTest.php
@@ -37,3 +37,13 @@ it('renders the session titles', function () {
     $response = $this->get('/votes');
     expect($response)->toHaveSelectorWithText('.beta', 'January 2021 · Brussels');
 });
+
+it('does not include primary votes that have not been matched to a voting list', function () {
+    Vote::factory([
+            'session_id' => Session::first(),
+            'type' => VoteTypeEnum::PRIMARY(),
+    ])->create();
+
+    $response = $this->get('/votes');
+    expect($response)->toHaveSelector('.vote-card', 2);
+});


### PR DESCRIPTION
@tillprochaska neuer Versuch upside_down_face

Ich bin mir nicht sicher, ob wir die neue Funktion brauchen oder haben wollen.
Es hat aber am Ende überwogen, dass ich dachte vielleicht will man (aus welchen Gründen auch immer) mal einfach alle primary votes haben, egal ob sie zugeordnet wurden oder nicht. Daher die neue Methode.

P.S. Sorry für den doppelten Spam.