### PR TITLE
Upgrade to Python 3.9

### DIFF
--- a/ansible/vars/general.yml
+++ b/ansible/vars/general.yml
@@ -1,7 +1,7 @@
 ---
 php_version: 8.0
 node_version: 14
-python_version: 3.8
+python_version: 3.9
 poetry_executable: "{{ ansible_facts.env.HOME }}/.poetry/bin/poetry"
 epvotes_version: main
 epvotes_install_dir: "/var/www/virtual/{{ uberspace_user }}/epvotes"


### PR DESCRIPTION
We ran into a bug because isocalendar in Python 3.8 returns a tuple, but we were expecting a named tuple.