### PR TITLE
Do not push updated search query to history

### DIFF
--- a/app/resources/js/components/search-results-page.js
+++ b/app/resources/js/components/search-results-page.js
@@ -150,7 +150,7 @@ export default (options = {}) => ({
       url.searchParams.delete('q');
     }
 
-    window.history.pushState({}, '', url);
+    window.history.replaceState({}, '', url);
   },
 
   restoreFromUrl() {


### PR DESCRIPTION
Instead, simply replace the current URL, keeping the browser’s back button usable.

Close #492