### PR TITLE
Add JSON endpoint for vote results

### DIFF
--- a/app/app/Http/Controllers/VotingListsController.php
+++ b/app/app/Http/Controllers/VotingListsController.php
@@ -122,6 +122,35 @@ class VotingListsController extends Controller
         return response($csv, 200, ['Content-Type' => 'text/csv']);
     }
 
+    public function json(VotingList $votingList)
+    {
+        $members = $this->members($votingList)->map(function ($member) {
+            return [
+                'member_id' => $member->id,
+                'last_name' => $member->last_name,
+                'first_name' => $member->first_name,
+                'group' => [
+                    'abbreviation' => $member->group->abbreviation,
+                    'name' => $member->group->name,
+                ],
+                'country' => [
+                    'code' => $member->country->value,
+                    'name' => $member->country->label,
+                ],
+                'position' => $member->pivot->position->label,
+                ];
+        })->toArray();
+
+        $vote = [
+            'title' => $votingList->display_title,
+            'date' => $votingList->date,
+            'result' => $votingList->result->label,
+            'members' => $members,
+        ];
+
+        return response()->json($vote);
+    }
+
     private function members(VotingList $votingList)
     {
         return $votingList

--- a/app/resources/lang/en/voting-lists.php
+++ b/app/resources/lang/en/voting-lists.php
@@ -34,8 +34,9 @@ return [
 
     'download' => [
         'heading' => 'Open Data',
-        'text' => 'We provide raw voting data for this vote, ready to use in your own analyses, visualizations or applications. Data is provided in CSV format and licensed under Creative Commons Attribution License 4.0.',
-        'button-label' => 'Download',
+        'text' => 'We provide raw voting data for this vote, ready to use in your own analyses, visualizations or applications. Data is provided in CSV or JSON format and licensed under Creative Commons Attribution License 4.0.',
+        'button-label-csv' => 'CSV',
+        'button-label-json' => 'JSON',
     ],
 
     'related-votes-list' => [

--- a/app/resources/views/components/voting-list/download-panel.blade.php
+++ b/app/resources/views/components/voting-list/download-panel.blade.php
@@ -8,6 +8,15 @@
         size="lg"
         href="{{ route('voting-list.csv', $votingList) }}"
     >
-        {{ __('voting-lists.download.button-label') }}
+        {{ __('voting-lists.download.button-label-csv') }}
     </x-button>
+
+    <x-button
+        size="lg"
+        href="{{ route('voting-list.json', $votingList) }}"
+    >
+        {{ __('voting-lists.download.button-label-json') }}
+    </x-button>
+
+
 </x-action-panel>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -28,6 +28,7 @@ Route::get('/monitoring/votes/{vote}', [MonitoringController::class, 'showVotes'
 
 Route::get('/votes', [VotingListsController::class, 'index'])->name('voting-lists.index');
 Route::get('/votes/{votingList}.csv', [VotingListsController::class, 'csv'])->name('voting-list.csv');
+Route::get('/votes/{votingList}.json', [VotingListsController::class, 'json'])->name('voting-list.json');
 Route::get('/votes/{votingList}', [VotingListsController::class, 'show'])->name('voting-list.show');
 Route::get('/votes/{votingList}/summary', [VotingListsController::class, 'summary'])->name('voting-list.summary');
 Route::get('/votes/{votingList}/related', [VotingListsController::class, 'related'])->name('voting-list.related');

--- a/app/tests/Feature/Http/VotingLists/JsonTest.php
+++ b/app/tests/Feature/Http/VotingLists/JsonTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\CountryEnum;
+use App\Enums\VoteResultEnum;
+use App\Group;
+use App\Member;
+use App\Vote;
+use App\VoteCollection;
+use App\VotingList;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    $date = new Carbon('2021-05-23');
+    $display_title = 'Budged 2020';
+
+    $greens = Group::factory([
+        'code' => 'GREENS',
+        'name' => 'Greens/European Free Alliance',
+        'abbreviation' => 'Greens/EFA',
+    ])->create();
+
+    $this->greensFor = Member::factory([
+        'first_name' => 'Jane',
+        'last_name' => 'DOE',
+        'country' => CountryEnum::NL(),
+    ])->activeAt($date, $greens)->count(1);
+
+    $this->votingList = VotingList::factory([
+        'date' => $date,
+        'vote_id' => Vote::factory([
+            'result' => VoteResultEnum::REJECTED(),
+            'vote_collection_id' => VoteCollection::factory([
+            'title' => 'Budget 2020',
+            ]),
+        ]),
+        'description' => 'Budged 2020',
+        ])
+        ->withMembers('FOR', $this->greensFor)
+        ->create();
+});
+
+it('creates a JSON with one row per member', function () {
+    $response = $this->get("/votes/{$this->votingList->id}.json")->json();
+
+    $expected = [
+        'title' => 'Budget 2020',
+        'date' => '2021-05-23T00:00:00.000000Z',
+        'result' => 'rejected',
+        'members' => [
+            [
+                'member_id' => $this->votingList->members()->first()->id,
+                'last_name' => 'DOE',
+                'first_name' => 'Jane',
+                'group' => [
+                    'abbreviation' => 'Greens/EFA',
+                    'name' => 'Greens/European Free Alliance',
+                ],
+                'country' => [
+                    'code' => 'NL',
+                    'name' => 'Netherlands',
+                ],
+                'position' => 'FOR',
+            ],
+        ],
+    ];
+
+    expect(Member::count())->toEqual(1);
+    expect($response)->toEqual($expected);
+});
+
+it('sets correct content type', function () {
+    $response = $this->get("/votes/{$this->votingList->id}.json");
+    expect($response)->toHaveHeader('Content-Type', 'application/json');
+});


### PR DESCRIPTION
Implements issue [568](https://github.com/HowTheyVote/epvotes/issues/568). 

This PR adds a new endpoint which is returning the voting results as a JSON. Moreover it adds a new button in the frontend to download the json:


<img width="759" alt="Screenshot 2021-11-08 at 15 55 05" src="https://user-images.githubusercontent.com/32880898/140764375-71a6546e-736e-45f7-9f16-cacc355d3b32.png">
 