### PR TITLE
Fix `composer install` in CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           ${{ runner.os }}-
 
     - name: Install PHP dependencies
-      run: composer install
+      run: composer install --no-interaction
 
     - name: Install Node.js dependencies
       run: npm ci

--- a/ansible/roles/deployment/tasks/main.yml
+++ b/ansible/roles/deployment/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - name: Install composer dependencies
   shell:
-    cmd: "composer install"
+    cmd: "composer install --no-interaction"
     chdir: "{{ epvotes_install_dir }}/app"
 
 - name: Create env file for app

--- a/app/composer.json
+++ b/app/composer.json
@@ -48,7 +48,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Composer recently introduced a change that will prompt you to confirm to install any plugins that come with packages. This is the case for pest, so our CI runs failed after reaching a timeout, because composer waited for user input.

The solution is to add the pest plugin to our `composer.json`, and in general (and to prevent similar issues in the future) to run composer commands non-interactively in CI/CD.