### PR TITLE
Enforce (current) `poetry` version

### DIFF
--- a/ansible/roles/setup/tasks/main.yml
+++ b/ansible/roles/setup/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Install Poetry
   pip:
-    name: poetry
+    name: "poetry=={{ poetry_version }}"
     executable: "pip{{ python_version }}"
     extra_args: --user
     state: present

--- a/ansible/vars/general.yml
+++ b/ansible/vars/general.yml
@@ -3,6 +3,7 @@ php_version: 8.0
 node_version: 14
 epvotes_version: main
 python_version: '3.10'
+poetry_version: '1.2.0'
 epvotes_install_dir: "/var/www/virtual/{{ uberspace_user }}/epvotes"
 epvotes_domains:
   - howtheyvote.eu


### PR DESCRIPTION
This fixes a compatibility problem between poetry `1.2.0` and `1.1` which caused `setuptools` to go amiss, resulting in the scraper service being unable to start.

Closes #754. I deployed this branch and made sure that the scrapers are indeed running. 