### PR TITLE
Add switch to manually exempt Sessions from voting list scraping

### DIFF
--- a/app/database/migrations/2022_09_20_134047_add_ignore_when_scraping_voting_lists_column_on_sessions_table.php
+++ b/app/database/migrations/2022_09_20_134047_add_ignore_when_scraping_voting_lists_column_on_sessions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIgnoreWhenScrapingVotingListsColumnOnSessionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->boolean('ignore_when_scraping_voting_lists')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/app/routes/console.php
+++ b/app/routes/console.php
@@ -120,6 +120,7 @@ Artisan::command('scrape:all {--term=}', function (int $term) {
     // scrape voting lists and votes for the days of the session.
     $session = Session::query()
         ->whereDoesntHave('votes')
+        ->whereNot('ignore_when_scraping_voting_lists')
         ->orderBy('start_date', 'desc')
         ->first();
 


### PR DESCRIPTION
This fixes a crash that occurs when we try to scrape the voting lists for a Session that has no voting lists in scrape:all. In the future, we can manually mark such Sessions. I opted for manual marking as the implications of exempting a Session are quite severe and this case is very rare.