### PR TITLE
Fixes for current deployment

### DIFF
--- a/app/routes/console.php
+++ b/app/routes/console.php
@@ -120,7 +120,7 @@ Artisan::command('scrape:all {--term=}', function (int $term) {
     // scrape voting lists and votes for the days of the session.
     $session = Session::query()
         ->whereDoesntHave('votes')
-        ->whereNot('ignore_when_scraping_voting_lists')
+        ->whereNull('ignore_when_scraping_voting_lists')
         ->orderBy('start_date', 'desc')
         ->first();
 

--- a/scrapers/ep_votes/scrapers.py
+++ b/scrapers/ep_votes/scrapers.py
@@ -270,7 +270,6 @@ class VotingListsScraper(Scraper):
         "Aguilera García": "Aguilera",
         "Rodríguez-Piñero Fernández": "Rodríguez-Piñero",
         "Papadakis Konstantinos": "Papadakis",
-        "Miranda": "Miranda Paz",
     }
 
     def __init__(self, date: date, term: int):


### PR DESCRIPTION
The usage of the alternate name is what broke our neck yesterday.
What I believe happened is, that the EP profile for her in the past gave the name "Miranda Paz", as can be seen with the [wayback machine](http://web.archive.org/web/20191230024743/http://www.europarl.europa.eu/meps/en/24942/ANA+MARIA_MIRANDA+PAZ/history/8). When she came into parliament again this year (during the "summer pause"), this changed to just Miranda. We scraped that change and adapted our entry in the members database accordingly.
In the past, we introduced the alternate name, as we matched based on "Miranda Paz", while the Voting Lists from the Parliament **always** just contained Miranda.
As this is now consistent within the original data sources from the parliament, the alternate name broke the scraping, as there is no member with this name anymore.