### PR TITLE
Fix meilisearch role

### DIFF
--- a/ansible/roles/meilisearch/tasks/installation.yml
+++ b/ansible/roles/meilisearch/tasks/installation.yml
@@ -4,14 +4,6 @@
     path: "{{ ansible_facts.env.HOME }}/bin/meilisearch-{{ meilisearch_version }}"
   register: exec_stats
 
-- name: Copy service configuration
-  notify:
-    - Reread meilisearch service
-    - Restart meilisearch service
-  template:
-    src: etc/services.d/meilisearch.ini.j2
-    dest: "{{ ansible_facts.env.HOME }}/etc/services.d/meilisearch.ini"
-
 - name: Clone git repository
   git:
     repo: https://github.com/meilisearch/MeiliSearch
@@ -28,6 +20,14 @@
     dest: "{{ ansible_facts.env.HOME }}/bin/meilisearch-{{ meilisearch_version }}"
     mode: "u+x"
   when: not exec_stats.stat.exists
+
+- name: Copy service configuration
+  notify:
+    - Reread meilisearch service
+    - Restart meilisearch service
+  template:
+    src: etc/services.d/meilisearch.ini.j2
+    dest: "{{ ansible_facts.env.HOME }}/etc/services.d/meilisearch.ini"
 
 - meta: flush_handlers
 

--- a/ansible/roles/meilisearch/tasks/installation.yml
+++ b/ansible/roles/meilisearch/tasks/installation.yml
@@ -19,18 +19,12 @@
     version: "tags/v{{ meilisearch_version }}"
   when: not exec_stats.stat.exists
 
-- name: Compile from source
-  command:
-    cmd: cargo build --release
-    chdir: "{{ meilisearch_install_dir }}"
-  when: not exec_stats.stat.exists
-
-- name: Copy executable to bin directory
+- name: Download prebuilt binary
   notify:
+    - Reread meilisearch service
     - Restart meilisearch service
-  copy:
-    src: "{{ meilisearch_install_dir }}/target/release/meilisearch"
-    remote_src: yes
+  get_url:
+    url: "https://github.com/meilisearch/meilisearch/releases/download/v{{ meilisearch_version }}/meilisearch-linux-amd64"
     dest: "{{ ansible_facts.env.HOME }}/bin/meilisearch-{{ meilisearch_version }}"
     mode: "u+x"
   when: not exec_stats.stat.exists


### PR DESCRIPTION
Compiling the most recent release failed, but they now provide prebuilt binaries, so I updated the Ansible roles to use that instead of building from source.