### PR TITLE
Adapt scraping logic to fit separate vote collection files for each day

### DIFF
--- a/app/routes/console.php
+++ b/app/routes/console.php
@@ -146,17 +146,6 @@ Artisan::command('scrape:all {--term=}', function (int $term) {
             '--term' => $term,
             '--date' => $date,
         ]);
-
-        // Vote collection documents on the Parliament's website
-        // include all vote collections for the session, including
-        // vote collections that did not take place on the given
-        // day, i.e. we have to make sure to import vote collections
-        // only for the first day of the plenary session.
-        // It is necessary to loop over all days, since the actual first day where
-        // the collections are available is not always the first day of the session.
-        if (VoteCollection::count() > $count) {
-            break;
-        }
     }
 
     foreach ($period as $date) {


### PR DESCRIPTION
Previously, the VOT XML files (corresponding to the tables of votes) contained the same contents for each day in a session where votes were held.

This was changed recently, so that e.g., these files for [15.03](https://www.europarl.europa.eu/doceo/document/PV-9-2023-03-15-VOT_EN.xml) and for [16.03](https://www.europarl.europa.eu/doceo/document/PV-9-2023-03-16-VOT_EN.xml) are different.
This change was done in a way that affects (as far as I can tell) all older files as well.

This was the cause of us only retrieving vote collections for a single day of sessions over the last months.