### PR TITLE
FIx `ParliamentSessionsScraper` for Sessions that span multiple months

### DIFF
--- a/scrapers/ep_votes/scrapers.py
+++ b/scrapers/ep_votes/scrapers.py
@@ -589,7 +589,7 @@ class ParliamentSessionsScraper(Scraper):
     def _extract_data(self) -> List[Session]:
         sessions = self._resource["sessionCalendar"]
 
-        # This assumes that a session never spans multiple months or years
+        # We assume that a session never spans multiple years
         sessions_in_year = [
             session for session in sessions if int(session["year"]) == self.year
         ]
@@ -604,16 +604,20 @@ class ParliamentSessionsScraper(Scraper):
 
     def _session(self, session: dict) -> Session:
         return Session(
-            start_date=self._parse_date(session["dayStartDateSession"]),
-            end_date=self._parse_date(session["dayEndDateSession"]),
+            start_date=self._parse_date(
+                session["dayStartDateSession"], session["monthStartDateSession"]
+            ),
+            end_date=self._parse_date(
+                session["dayEndDateSession"], session["monthEndDateSession"]
+            ),
             location=None,
         )
 
-    def _parse_date(self, day: str) -> date:
+    def _parse_date(self, day: str, month: str) -> date:
         return date.fromisoformat(
             str(self.year).rjust(2, "0")
             + "-"
-            + str(self.month).rjust(2, "0")
+            + month.rjust(2, "0")
             + "-"
             + day.rjust(2, "0")
         )

--- a/scrapers/tests/test_scrapers.py
+++ b/scrapers/tests/test_scrapers.py
@@ -823,3 +823,13 @@ def test_parliament_sessions_scraper_run(mock_request):
     session_two = Session(date(2021, 3, 24), date(2021, 3, 25), None)
 
     assert set(result) == set([session_two, session_one])
+
+
+def test_parliament_sessions_scraper_handles_sessions_spanning_months(mock_request):
+    scraper = ParliamentSessionsScraper(term=9, month=5, year=2023)
+    result = scraper.run()
+
+    session_one = Session(date(2023, 5, 8), date(2023, 5, 11), None)
+    session_two = Session(date(2023, 5, 31), date(2023, 6, 1), None)
+
+    assert set(result) == set([session_two, session_one])


### PR DESCRIPTION
We previously assumed, that a session never spans multiple years or months. This assumption does not hold, and the first such session that we  encountered lead to a faulty session entry that in turn got displayed on the landing-page in a nonsensical way. This removes the assumption of a session never spanning multiple months. For years, we still keep our assumption.

Closes #882.